### PR TITLE
Fix size of buffer returned by `MqttBinding.get_read_buffer()`

### DIFF
--- a/src/packet_v2/connect.rs
+++ b/src/packet_v2/connect.rs
@@ -37,7 +37,7 @@ use core::fmt;
 /// assert_eq!(packet.client_id(), "test");
 /// assert_eq!(packet.flags().clean_session(), true);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Connect {
     inner: UnverifiedConnect,
 }
@@ -98,6 +98,18 @@ impl TryFrom<Bytes> for Connect {
     }
 }
 
+impl From<Connect> for Bytes {
+    fn from(value: Connect) -> Bytes {
+        value.inner.inner
+    }
+}
+
+impl From<Connect> for Packet {
+    fn from(value: Connect) -> Packet {
+        Packet::Connect(value)
+    }
+}
+
 impl std::fmt::Debug for Connect {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CONNECT")
@@ -110,7 +122,7 @@ impl std::fmt::Debug for Connect {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct UnverifiedConnect {
     pub inner: Bytes,
 }

--- a/src/packet_v2/ping_req.rs
+++ b/src/packet_v2/ping_req.rs
@@ -1,5 +1,5 @@
 //! Providing [`PingReq`]
-use crate::{Frame, decode::DecodingError};
+use crate::{Frame, Packet, decode::DecodingError};
 use bytes::Bytes;
 
 // A PINGREQ packet consists of only a header of two bytes.
@@ -58,6 +58,12 @@ impl TryFrom<&[u8]> for PingReq {
 impl From<PingReq> for Bytes {
     fn from(_: PingReq) -> Bytes {
         Bytes::copy_from_slice(&PINGREQ)
+    }
+}
+
+impl From<PingReq> for Packet {
+    fn from(value: PingReq) -> Packet {
+        Packet::PingReq(value)
     }
 }
 


### PR DESCRIPTION
The method incorrectly assumed that each packet is at least 4 bytes. That's incorrect. Some packets are 2 bytes only.

This incorrect assumption caused problems with `PingReq`'s new  decoder. This  commit fixes this.

Fixes  #5 