### PR TITLE
Add wasm support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "async-net",
  "bytes",
  "futures-lite",
+ "js-sys",
  "log",
  "macro_rules_attribute",
  "pretty_assertions",
@@ -1757,6 +1758,9 @@ dependencies = [
  "simple_logger",
  "smol",
  "smol-macros",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -1952,6 +1956,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -1967,6 +1972,19 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2006,6 +2024,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,18 @@ edition = "2024"
 [dependencies]
 async-broadcast = { version = "0.7.2", default-features = false }
 async-channel = { version = "2.5.0", default-features = false }
-async-io = { version = "2.4.1", default-features = false }
 bytes = { version = "1.10.1", default-features = false, features = ["std"] }
 futures-lite = { version = "2.6.0", default-features = false, features = ["std", "race"] }
 log = "0.4.27"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+async-io = { version = "2.4.1", default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.77"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
+web-time = "1.1.0"
 
 [dev-dependencies]
 simple_logger = "5.0.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,13 +2,13 @@
 //!
 //! The `Client` holds a connection internally. Use a `ClientHandle` to
 //! read and write packets to this connection.
+use super::time::{Instant, timer_at};
 use super::{MqttBinding, Packet, Publish, Subscribe};
 use async_channel::{self, Receiver, RecvError, SendError, Sender};
-use async_io::Timer;
+
 use bytes::Bytes;
 use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, FutureExt};
 use log::error;
-use std::time::Instant;
 
 pub struct Client<S: AsyncRead + AsyncWrite + Unpin> {
     // Socket for interacting with the MQTT broker.
@@ -29,7 +29,7 @@ pub struct Client<S: AsyncRead + AsyncWrite + Unpin> {
 
 impl<S> Client<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + 'static,
 {
     pub fn new(options: Options, socket: S) -> Self {
         // TODO: What size do we need?
@@ -88,7 +88,7 @@ where
 
             let future1 = async { Winner::Future1(self.socket.read(&mut buffer).await) };
             let future2 = async {
-                Timer::at(timeout).await;
+                timer_at(timeout).await;
                 Winner::Future2
             };
             let future3 = async { Winner::Future3(self.receiver.recv().await) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,20 +46,14 @@ pub use client::{Client, ClientHandle, Options};
 use log::{debug, error};
 pub use packet::*;
 use packet_v2::{connect::Connect, ping_req::PingReq};
-use std::time::{Duration, Instant, SystemTime};
 
 pub mod packet;
 pub mod packet_v2;
+pub mod time;
 mod validate;
 
-pub fn packet_identifier() -> u16 {
-    let seconds = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(n) => n.as_millis(),
-        Err(_) => panic!("SystemTime before UNIX EPOCH!"),
-    };
-
-    seconds as u16
-}
+use crate::time::Instant;
+use std::time::Duration;
 
 pub fn connect(client_id: String, keep_alive_interval: u16) -> Packet {
     Connect::builder()

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -5,9 +5,9 @@ use crate::packet_v2::connack::ConnAck;
 use crate::packet_v2::connect::Connect;
 use crate::packet_v2::ping_req::PingReq;
 use crate::packet_v2::ping_resp::PingResp;
+use crate::time::SystemTime;
 use bytes::{BufMut, Bytes, BytesMut};
 use std::fmt;
-use std::io::Read;
 
 #[derive(Clone)]
 pub enum Packet {
@@ -605,11 +605,10 @@ impl std::fmt::Debug for PubAck {
 }
 
 pub fn packet_identifier() -> u16 {
-    let mut buf = vec![0u8, 2];
-    std::fs::File::open("/dev/urandom")
-        .expect("Failed to open /dev/urandom.")
-        .read_exact(&mut buf)
-        .expect("Failed to obtain random data.");
+    let seconds = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(n) => n.as_millis(),
+        Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+    };
 
-    (buf[0] as u16 * 256) + buf[1] as u16
+    seconds as u16
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,93 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::{Instant, SystemTime};
+
+#[cfg(target_arch = "wasm32")]
+pub use web_time::{Instant, SystemTime};
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use js_sys::Promise;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen_futures::JsFuture;
+    use web_time::Instant;
+
+    pub struct Timeout {
+        id: JsValue,
+        inner: JsFuture,
+    }
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_name = setTimeout)]
+        fn set_timeout(closure: JsValue, millis: f64) -> JsValue;
+
+        #[wasm_bindgen(js_name = clearTimeout)]
+        fn clear_timeout(id: &JsValue);
+    }
+
+    impl Timeout {
+        pub fn new(dur: Duration) -> Timeout {
+            let millis = dur
+                .as_secs()
+                .checked_mul(1000)
+                .unwrap()
+                .checked_add(dur.subsec_millis() as u64)
+                .unwrap() as f64; // TODO: checked cast
+
+            let mut id = None;
+            let promise = Promise::new(&mut |resolve, _reject| {
+                id = Some(set_timeout(resolve.into(), millis));
+            });
+
+            Timeout {
+                id: id.unwrap(),
+                inner: JsFuture::from(promise),
+            }
+        }
+    }
+
+    impl Future for Timeout {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+            Pin::new(&mut self.inner).poll(cx).map(|_| ())
+        }
+    }
+
+    impl Drop for Timeout {
+        fn drop(&mut self) {
+            clear_timeout(&self.id);
+        }
+    }
+
+    /// Creates a timer that emits an event once at the given time instant.
+    /// This recreates `async_io::Timer::at` in wasm using browser APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::{Duration, Instant};
+    ///
+    /// # futures_lite::future::block_on(async {
+    /// let now = Instant::now();
+    /// let when = now + Duration::from_secs(1);
+    /// timer_at(when).await;
+    /// # });
+    /// ```
+    pub async fn timer_at(timeout: Instant) {
+        let duration = timeout.duration_since(Instant::now());
+        Timeout::new(duration).await;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn timer_at(timeout: Instant) {
+    async_io::Timer::at(timeout).await;
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::timer_at;


### PR DESCRIPTION
time module re-exports versions of Instant and SystemTime depending on the target, also reimplements async_io::Timer::at to support the browser

Use packet_identifier that doesn't depend on reading /dev/urandom

Drop requirement of `Send` in the `Client`, the browser is single threaded, so websocket implementation doesn't implement `Send`.

Fixes: #13