### PR TITLE
Fix encoding/decoding variable length field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+[195d736](195d736acfe1744669f73ed3c5c9cb7f978210e7)...[e7d7f87](e7d7f87106b13033ae4eb9d053e8ab4c25ca568d)
+
+### Changes
+
+- GH-40 Fix encoding/decoding variable length field - ([e7d7f87](e7d7f87106b13033ae4eb9d053e8ab4c25ca568d)) - GH-40 (https://github.com/eastern-oak/tjiftjaf/issues/40)
+
 ## [0.1.0] - 2025-11-02
 
 Initial release

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -17,7 +17,11 @@ pub fn bytes(value: &[u8]) -> Bytes {
 
     bytes.freeze()
 }
+
 pub fn remaining_length(length: usize) -> Bytes {
+    // TODO: proper validation and error handling.
+    assert!(length <= 268_435_455);
+
     let mut length = length;
     let mut bytes = BytesMut::with_capacity(1);
 

--- a/src/packet_v2/mod.rs
+++ b/src/packet_v2/mod.rs
@@ -1,4 +1,4 @@
-use crate::decode::DecodingError;
+use crate::decode::{self, DecodingError};
 mod ack;
 pub mod connack;
 pub mod connect;
@@ -37,7 +37,7 @@ pub trait UnverifiedFrame {
         // * the value encoded is this field
         // * the length of this field (between 1 and 3 bytes)
         // * 1 byte for encoding the packet type
-        for n in 1..4 {
+        for n in 1..5 {
             let byte = inner.get(n).ok_or(DecodingError::NotEnoughBytes {
                 minimum: 1,
                 actual: 0,

--- a/src/packet_v2/subscribe.rs
+++ b/src/packet_v2/subscribe.rs
@@ -289,12 +289,25 @@ mod test {
     #[test]
     fn test_subscribe() {
         let frame = Subscribe::builder("topic-1", QoS::AtMostOnceDelivery).build();
-        dbg!(frame.as_bytes());
         let _: Subscribe = frame.into_bytes().try_into().unwrap();
 
         let frame = Subscribe::builder("topic-1", QoS::AtMostOnceDelivery)
             .add_topic("topic-2", QoS::AtLeastOnceDelivery)
             .build();
         let _: Subscribe = frame.into_bytes().try_into().unwrap();
+    }
+
+    // Issue #40 tracks a bug when the `Builder` panics
+    // trying to create a `Subscribe` with a lot of topics.
+    //
+    // This test verifies the fix works. `Builder.build()` must _not_ panic.
+    #[test]
+    fn gh_40_fix_panic_when_building_subscribe_with_a_lot_of_topics() {
+        let mut builder = Subscribe::builder("topic-1", QoS::AtMostOnceDelivery);
+        for _ in 0..1145729 {
+            builder = builder.add_topic("", QoS::AtMostOnceDelivery);
+        }
+
+        builder.build();
     }
 }


### PR DESCRIPTION
The encoder and decoder for the variable length
field contained bugs. As result, large values
were not encoded and decoded correctly.

Among others, that prevented users from building
a `Subscribe` packet with a large number of topics.