### PR TITLE
GH-45 Fix panic on `Frame.header()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - GH-40 Fix encoding/decoding variable length field - ([e7d7f87](e7d7f87106b13033ae4eb9d053e8ab4c25ca568d)) - GH-40 (https://github.com/eastern-oak/tjiftjaf/issues/40)
+- GH-45 Fix panic on `Frame.header()` - ([5373520](537352019d55264d7afe5afa0215d31908ce1584)) - GH-45 (https://github.com/eastern-oak/tjiftjaf/issues/45)
 
 ## [0.1.0] - 2025-11-02
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -255,9 +255,8 @@ pub trait Frame {
             return &inner[0..3];
         } else if inner[3] & 128 == 0 {
             return &inner[0..4];
-        }
-
-        panic!("Illegal packet")
+        };
+        &inner[0..5]
     }
 
     fn offset_variable_header(&self) -> usize {

--- a/src/packet_v2/mod.rs
+++ b/src/packet_v2/mod.rs
@@ -1,4 +1,4 @@
-use crate::decode::{self, DecodingError};
+use crate::decode::DecodingError;
 mod ack;
 pub mod connack;
 pub mod connect;

--- a/src/packet_v2/subscribe.rs
+++ b/src/packet_v2/subscribe.rs
@@ -310,4 +310,20 @@ mod test {
 
         builder.build();
     }
+
+    // Issue #45 tracks a bug when the `Subscribe.topics()` panics
+    // if the message includes a lot of topics.
+    //
+    // This test verifies the fix works. Iterating over the topics must _not_ panic.
+    #[test]
+    fn gh_45_fix_panic_when_iterating_over_the_topics_of_large_subscribe() {
+        let mut builder = Subscribe::builder("topic-1", QoS::AtMostOnceDelivery);
+        for _ in 0..1145729 {
+            builder = builder.add_topic("", QoS::AtMostOnceDelivery);
+        }
+
+        let packet = builder.build();
+        let topics = packet.topics();
+        for _ in topics {}
+    }
 }


### PR DESCRIPTION
`Frame.header()` failed on packets that used 4 bytes the encode the remaining length field.

`Frame.header()` only accounted for the first 3 bytes of the field.