### PR TITLE
GH-54 Encode and decode the will in `Connect`

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,6 @@
 use async_net::TcpStream;
 use futures_lite::FutureExt;
-use tjiftjaf::{Client, Options, QoS, packet_identifier};
+use tjiftjaf::{Client, QoS, packet_identifier, packet_v2::connect::Connect};
 
 fn main() {
     simple_logger::init_with_level(log::Level::Debug).unwrap();
@@ -9,11 +9,12 @@ fn main() {
             .await
             .expect("Failed connecting to MQTT broker.");
 
-        let mut options = Options::default();
-        options.client_id = Some("tjiftjaf".into());
-        options.username = Some("ro".into());
-        options.password = Some("readonly".into());
-        let client = Client::new(options, stream);
+        let connect = Connect::builder()
+            .client_id("tjiftjaf")
+            .username("ro")
+            .password("readonly")
+            .build();
+        let client = Client::new(connect, stream);
 
         // Spawn the event loop that monitors the socket.
         // `handle` allows for sending and receiving MQTT packets.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "tjiftjaf"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arbitrary",
  "async-broadcast",

--- a/src/packet_v2/disconnect.rs
+++ b/src/packet_v2/disconnect.rs
@@ -90,7 +90,7 @@ mod test {
 
     #[test]
     fn test_variable_header() {
-        // The PingReq message doesn't have a variable header.
-        assert_eq!(Disconnect.variable_header(), &[])
+        // The Disconnect message doesn't have a variable header.
+        assert!(Disconnect.variable_header().is_empty())
     }
 }

--- a/src/packet_v2/ping_req.rs
+++ b/src/packet_v2/ping_req.rs
@@ -94,6 +94,6 @@ mod test {
     #[test]
     fn test_variable_header() {
         // The PingReq message doesn't have a variable header.
-        assert_eq!(PingReq.variable_header(), &[])
+        assert!(PingReq.variable_header().is_empty())
     }
 }

--- a/src/packet_v2/ping_resp.rs
+++ b/src/packet_v2/ping_resp.rs
@@ -85,6 +85,6 @@ mod test {
     #[test]
     fn test_variable_header() {
         // The PingResp message doesn't have a variable header.
-        assert_eq!(PingResp.variable_header(), &[])
+        assert!(PingResp.variable_header().is_empty())
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,8 +6,8 @@ use pretty_assertions::assert_eq;
 use smol::Timer;
 use std::{future, time::Duration};
 use tjiftjaf::{
-    Client, Frame, Options, Packet, PacketType,
-    packet_v2::{connack::ConnAck, publish::Publish},
+    Client, Frame, Packet, PacketType,
+    packet_v2::{connack::ConnAck, connect::Connect, publish::Publish},
 };
 mod broker;
 use macro_rules_attribute::apply;
@@ -20,12 +20,8 @@ async fn create_client(port: u16) -> Client<TcpStream> {
         .await
         .expect("Failed to open TCP connection to broker.");
 
-    let options = Options {
-        client_id: Some("test".to_string()),
-        keep_alive: 5,
-        ..Options::default()
-    };
-    Client::new(options, stream)
+    let connect = Connect::builder().client_id("test").keep_alive(5).build();
+    Client::new(connect, stream)
 }
 
 // Connect a client to a broker.


### PR DESCRIPTION
The builder now uses the type state pattern. That
makes it statically impossible to build an invalid
`Connect` packet.

For example, one can only configure a password _after_
one configured a username. And one can't configure
a will QoS without a will topic and will message.

This change is backwards incompatible.  

First, the type of `connect::Builder`
changed and received 2 generic parameters. 

Second, `Options` have been removed. `Client::with_options()` has been
renamed to `Client::with_connect()`. 
