### PR TITLE
GH-77 Fix spin loop when keep alive interval is 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl MqttBinding {
             // `MqttBinding.poll_timeout()` returns an value 30 years from now.
             //
             // So if keep_alive is 0 _and_ there is no IO for 30 years, then the binding
-            // violates the spec by emimtting a PINGREQ.
+            // violates the spec by emitting a PINGREQ.
             self.transmits.push(Packet::PingReq(PingReq))
         }
     }


### PR DESCRIPTION
The fix for GH-53 was not complete. The `Client`
went into a spin loop under these conditions:
* keep_alive interval is 0
* there was no IO for 300 seconds

That problem has been fixed in 2 ways. First,
the interval has been changed from 300 seconds to 30 years.

Second, if no IO happened for 30 years a PINGREQ
is scheduled, even if the keep_alive interval is 0.

That is against the MQTT spec, since a keep alive
interval of 0 disables PINGREQs. But this violation is very unlikely to ever happen.