### PR TITLE
GH-59 Add blocking `Client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.59.0",
 ]
@@ -1773,6 +1774,7 @@ dependencies = [
  "futures-lite",
  "log",
  "macro_rules_attribute",
+ "mio",
  "pretty_assertions",
  "rumqttd",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,14 @@ description = "Library including an encoder and decoder for MQTT v3.1.1. It also
 
 [dependencies]
 async-broadcast = { version = "0.7.2", default-features = false }
-async-channel = { version = "2.5.0", default-features = false }
+async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
 async-io = { version = "2.4.1", default-features = false }
 bytes = { version = "1.10.1", default-features = false, features = ["std"] }
 futures-lite = { version = "2.6.0", default-features = false, features = ["std", "race"] }
 log = "0.4.27"
 arbitrary = { version = "1", optional = true, features = ["derive"] }
+mio = { version = "1.0.4", optional = true, default-features = false, features = ["log", "os-poll", "net"] }
+
 
 [dev-dependencies]
 simple_logger = "5.0.0"
@@ -22,3 +24,13 @@ rumqttd = { version = "0.19.0", default-features = false }
 smol-macros = "0.1.1"
 async-net = { version = "2.0.0", default-features = false }
 smol = { version = "2.0.2", default-features = false }
+
+[features]
+blocking = ["mio"]
+
+[[example]]
+name = "blocking_client"
+required-features = ["blocking"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Tjiftjaf
 
-_tjiftjaf_ is a Rust library implementing MQTT 3.1.1.
+_tjiftjaf_ is a Rust library implementing MQTT 3.1.1 that supports various use cases.
 
-It features:
+# Features
+**MQTT Client**
 
-* encoding and decoding support for all 14 control packets.
-* a sans-io `Client` that supports both blocking and async paradigms. See [examples/](examples/) for more information.
+The crate provides a [blocking `Client`](https://docs.rs/tjiftjaf/latest/tjiftjaf/blocking/index.html)
+and an [asynchronous `Client`](https://docs.rs/tjiftjaf/latest/tjiftjaf/struct.Client.html).
+
+The latter does not require a specific runtime executor.
+
+Take a look at the examples:
+* [examples/client.rs](https://github.com/eastern-oak/tjiftjaf/blob/master/examples/client.rs) uses the executor [smol](https://docs.rs/smol/latest/smol/index.html)
+* [examples/blocking_client.rs](https://github.com/eastern-oak/tjiftjaf/blob/master/examples/blocking_client.rs) does _not_ use async.
 
 ## Do not use this crate
 

--- a/examples/blocking_client.rs
+++ b/examples/blocking_client.rs
@@ -1,0 +1,49 @@
+/// Run with `cargo run --example blocking_client --feature=blocking`
+use log::info;
+use std::env;
+use std::net::TcpStream;
+use tjiftjaf::{Connect, QoS, blocking::Client, packet_identifier};
+
+fn main() {
+    simple_logger::init_with_level(log::Level::Debug).unwrap();
+
+    let broker = env::args()
+        .nth(1)
+        .unwrap_or(String::from("test.mosquitto.org:1884"));
+    let stream = TcpStream::connect(broker).unwrap();
+
+    let connect = Connect::builder()
+        .client_id("tjiftjaf")
+        .username("ro")
+        .password("readonly")
+        .build();
+    let client = Client::new(connect, stream);
+
+    // Spawn the event loop that monitors the socket.
+    // `handle` allows for sending and receiving MQTT packets.
+    let (mut handle, _task) = client.spawn().unwrap();
+
+    handle
+        .subscribe("$SYS/broker/uptime", QoS::AtMostOnceDelivery)
+        .expect("Failed to subscribe to topic.");
+
+    let random_topic = packet_identifier().to_string();
+    handle
+        .subscribe(&random_topic, QoS::AtMostOnceDelivery)
+        .expect("Failed to subscribe to topic.");
+
+    let mut n = 0;
+    loop {
+        let packet = handle.publication().expect("Failed to read packet.");
+
+        n += 1;
+
+        let payload = String::from_utf8_lossy(packet.payload());
+        info!("{} - {:?}", packet.topic(), payload);
+        if packet.topic() == "$SYS/broker/uptime" {
+            handle
+                .publish(&random_topic, format!("{n} packets received").into())
+                .unwrap();
+        }
+    }
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,11 +1,17 @@
 use async_net::TcpStream;
 use futures_lite::FutureExt;
+use log::info;
+use std::env;
 use tjiftjaf::{Client, QoS, packet_identifier, packet_v2::connect::Connect};
 
 fn main() {
     simple_logger::init_with_level(log::Level::Debug).unwrap();
+    let broker = env::args()
+        .nth(1)
+        .unwrap_or(String::from("test.mosquitto.org:1884"));
+
     smol::block_on(async {
-        let stream = TcpStream::connect("test.mosquitto.org:1884")
+        let stream = TcpStream::connect(broker)
             .await
             .expect("Failed connecting to MQTT broker.");
 
@@ -43,7 +49,7 @@ fn main() {
                     n += 1;
 
                     let payload = String::from_utf8_lossy(packet.payload());
-                    println!("{} - {:?}", packet.topic(), payload);
+                    info!("{} - {:?}", packet.topic(), payload);
                     if packet.topic() == "$SYS/broker/uptime" {
                         handle
                             .publish(&random_topic, format!("{n} packets received").into())

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -1,0 +1,262 @@
+//! A blocking MQTT [`Client`].
+//!
+//! After creating the `Client`, [`Client::spawn()`] runs the
+//! client in a new thread. That method returns a [`ClientHandle`]
+//! allowing an application to [subscribe](ClientHandle::subscribe()) to topics, [publish](ClientHandle::publish()) messages and [retrieve
+//! publications](ClientHandle::publication()).
+//!
+//! Below you find a small snippet. Also, take a look at [examples/blocking_client.rs](https://github.com/eastern-oak/tjiftjaf/blob/master/examples/blocking_client.rs)
+//! for a more complete example.
+//!
+//! ```no_run
+//! use std::net::TcpStream;
+//! use tjiftjaf::{Connect, QoS, blocking::Client, packet_identifier};
+//!
+//! let stream = TcpStream::connect("localhost:1883").unwrap();
+//! let connect = Connect::builder()
+//!   .client_id("tjiftjaf")
+//!   .build();
+//!
+//! let client = Client::new(connect, stream);
+//!
+//! // Spawn the client in a new thread and obtain a handle to it.
+//! let (mut handle, _task) = client.spawn().unwrap();
+//!
+//! // Use the handle to subscribe to topics...
+//! handle.subscribe("$SYS/broker/uptime", QoS::AtMostOnceDelivery).unwrap();
+//!
+//! // ...to publish messages...
+//! handle.publish("some-topic", r"payload".into()).unwrap();
+//!
+//! // ...or to wait for publications on topics you subscribed to.
+//! let publication = handle.publication().unwrap();
+//! println!("Received message on topic {}", publication.topic());
+//! ```
+use crate::{
+    Connect, HandlerError, MqttBinding, Packet, QoS,
+    packet_v2::{publish::Publish, subscribe::Subscribe},
+};
+use async_channel::{Receiver, Sender};
+use mio::{Events, Interest, Poll, Token, Waker};
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    thread::{self, JoinHandle},
+    time::Instant,
+};
+
+const CLIENT: Token = Token(0);
+const PUBLISH: Token = Token(1);
+
+/// A blocking client to interact with a MQTT broker.
+///
+/// See the [module documentation](crate::blocking) for more information.
+pub struct Client {
+    socket: mio::net::TcpStream,
+    binding: MqttBinding,
+}
+
+impl Client {
+    /// Create a new `Client`.
+    pub fn new(connect: Connect, socket: TcpStream) -> Self {
+        Self {
+            socket: mio::net::TcpStream::from_std(socket),
+            binding: MqttBinding::from_connect(connect),
+        }
+    }
+
+    /// Start a new thread and move the `Client` to it.
+    pub fn spawn(
+        self,
+    ) -> Result<(ClientHandle, JoinHandle<Result<(), std::io::Error>>), std::io::Error> {
+        let poll = Poll::new()?;
+        let waker = Waker::new(poll.registry(), PUBLISH)?;
+
+        // TODO: GH-83 decide on capacity of channel.
+        // For communication _to_ the handler.
+        let (to_tx, to_rx) = async_channel::bounded(100);
+        // For communication _from_ the handler.
+        let (from_tx, from_rx) = async_channel::bounded(100);
+        let handle = ClientHandle::new(from_tx, to_rx, waker);
+
+        Ok((
+            handle,
+            thread::spawn(move || self.run(poll, to_tx, from_rx)),
+        ))
+    }
+
+    fn run(
+        mut self,
+        mut poll: Poll,
+        sender: Sender<Packet>,
+        receiver: Receiver<Packet>,
+    ) -> Result<(), std::io::Error> {
+        let mut events = Events::with_capacity(128);
+        poll.registry()
+            .register(&mut self.socket, CLIENT, Interest::READABLE)?;
+
+        // In this loop, check with the binding if any outbound
+        // packets are waiting. We call them 'transmits'. Send all pending
+        // transmits to the broker.
+        //
+        // When done, request a read buffer, read bytes from the broker until
+        // the buffer is full. Then, request the binding to decode the buffer.
+        // This operation might yield a mqtt::Packet for further processing.
+        loop {
+            while let Ok(packet) = receiver.try_recv() {
+                self.binding.send(packet);
+            }
+
+            while let Some(bytes) = self.binding.poll_transmits(Instant::now()) {
+                self.socket.write_all(&bytes)?;
+            }
+
+            let timeout = self.binding.poll_timeout();
+            poll.poll(&mut events, Some(timeout - Instant::now()))?;
+
+            for event in events.iter() {
+                if event.token() == PUBLISH {
+                    while let Ok(packet) = receiver.try_recv() {
+                        self.binding.send(packet);
+                    }
+                }
+
+                if event.token() != CLIENT {
+                    continue;
+                }
+
+                if !event.is_readable() {
+                    continue;
+                }
+
+                loop {
+                    let mut buffer = self.binding.get_read_buffer();
+                    self.socket.read_exact(&mut buffer)?;
+
+                    // TODO: If packet is invalid, try_decode() never returns a `Some`,
+                    // And thus the `loop` never breaks.
+                    // Maybe `try_decode` should return an Error. Maybe with variant `NotEnoughBytes`
+                    // to indicate that more bytes are expected and event loop should continue.
+                    // Any other error indicates an issue and event loop must break the loop
+                    if let Some(packet) = self.binding.try_decode(buffer.freeze(), Instant::now()) {
+                        sender
+                            .send_blocking(packet)
+                            .map_err(std::io::Error::other)?;
+                        break;
+                    };
+                }
+            }
+        }
+    }
+}
+
+/// A handle to interact with a `Client`.
+///
+/// See the [module documentation](crate::blocking) for more information.
+pub struct ClientHandle {
+    // Send packets to the `Client`.
+    sender: Sender<Packet>,
+
+    // Receive packets from the `Client`
+    receiver: Receiver<Packet>,
+
+    waker: Waker,
+}
+
+impl ClientHandle {
+    fn new(sender: Sender<Packet>, receiver: Receiver<Packet>, waker: Waker) -> Self {
+        Self {
+            sender,
+            receiver,
+            waker,
+        }
+    }
+
+    /// Subscribe to the given `topic` using the provided `qos`.
+    ///
+    /// ```no_run
+    /// # use std::net::TcpStream;
+    /// # use tjiftjaf::{Connect, blocking::Client, packet_identifier};
+    /// # let stream = TcpStream::connect("localhost:1883").unwrap();
+    /// # let connect = Connect::builder().build();
+    /// # let client = Client::new(connect, stream);
+    /// # let (mut handle, _task) = client.spawn().unwrap();
+    /// handle.subscribe("sensor/temperature/1", QoS::AtMostOnceDelivery).unwrap();
+    /// while let Ok(publish) = handle.publication() {
+    ///    println!(
+    ///       "On topic {} received {:?}",
+    ///        publish.topic(),
+    ///        publish.payload()
+    ///   );
+    /// }
+    /// ```
+    pub fn subscribe(&self, topic: impl Into<String>, qos: QoS) -> Result<(), HandlerError> {
+        let packet = Subscribe::builder(topic, qos).build_packet();
+        self.send(packet)
+    }
+
+    /// Publish `payload` to the given `topic`.
+    ///
+    /// ```no_run
+    /// # use std::net::TcpStream;
+    /// # use tjiftjaf::{Connect, blocking::Client, packet_identifier};
+    /// # let stream = TcpStream::connect("localhost:1883").unwrap();
+    /// # let connect = Connect::builder().build();
+    /// # let client = Client::new(connect, stream);
+    /// # let (mut handle, _task) = client.spawn();
+    /// handle
+    ///     .publish("sensor/temperature/1", Bytes::from("26.1"))
+    ///     .unwrap();
+    ///```
+    pub fn publish(
+        &self,
+        topic: impl Into<String>,
+        payload: bytes::Bytes,
+    ) -> Result<(), HandlerError> {
+        let packet = Publish::builder(topic, payload).build_packet();
+        self.send(packet)
+    }
+
+    /// Send any `Packet` to the broker.
+    fn send(&self, packet: Packet) -> Result<(), HandlerError> {
+        self.sender.send_blocking(packet)?;
+        self.waker.wake().map_err(|error| {
+            HandlerError(format!(
+                "Failed sending packet: couldn't wake the waker: {error:?}"
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn any_packet(&mut self) -> Result<Packet, HandlerError> {
+        let packet = self.receiver.recv_blocking()?;
+        Ok(packet)
+    }
+
+    /// Wait for the next [`Publish`] messages emitted by the broker.
+    ///
+    /// ```no_run
+    /// # use std::net::TcpStream;
+    /// # use tjiftjaf::{Connect, blocking::Client, packet_identifier};
+    /// # let stream = TcpStream::connect("localhost:1883").unwrap();
+    /// # let connect = Connect::builder().build();
+    /// # let client = Client::new(connect, stream);
+    /// # let (mut handle, _task) = client.spawn();
+    /// handle.subscribe("sensor/temperature/1", QoS::AtMostOnceDelivery).unwrap();
+    /// while let Ok(publish) = handle.publication() {
+    ///    println!(
+    ///       "On topic {} received {:?}",
+    ///        publish.topic(),
+    ///        publish.payload()
+    ///   );
+    /// }
+    /// ```
+    pub fn publication(&mut self) -> Result<Publish, HandlerError> {
+        loop {
+            let packet = self.any_packet()?;
+            if let Packet::Publish(publish) = packet {
+                return Ok(publish);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a blocking `Client` to complement the async `Client`.

Fixes #59