### PR TITLE
GH-107 Server to support wildcards `+` and `#`

### DIFF
--- a/src/aio/server.rs
+++ b/src/aio/server.rs
@@ -310,7 +310,7 @@ enum Message {
     Packet(String, Packet),
 }
 
-// Verify if a topic match a subscription. The subscription might
+// Verify if a topic match a subscription. The subscription may
 // include wildcards like `#` and `+`.
 fn does_topic_match_subscription(subscription: &str, topic: &str) -> bool {
     // If no wild cards are used, check for exact match
@@ -323,22 +323,25 @@ fn does_topic_match_subscription(subscription: &str, topic: &str) -> bool {
     }
 
     let mut topic_segments = topic.split('/');
-    let subscription_segments = subscription.split('/');
 
-    for segment in subscription_segments {
-        let Some(x) = topic_segments.next() else {
+    for filter in subscription.split('/') {
+        // The topic and a subscription using `+` must have the same
+        // number of segments. If the topic has less segments, it is no match.
+        let Some(segment) = topic_segments.next() else {
             return false;
         };
 
-        if segment == "+" {
+        if filter == "+" {
             continue;
         }
 
-        if segment != x {
+        if filter != segment {
             return false;
         }
     }
 
+    // The topic and a subscription using `+` must have the same
+    // number of segments. If the topic has more segments, it is no match.
     if topic_segments.next().is_some() {
         return false;
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -193,17 +193,20 @@ mod aio {
         let _handle = smol::spawn(task);
 
         handle_1
-            .subscribe(TOPIC, tjiftjaf::QoS::AtLeastOnceDelivery)
+            .subscribe("test/#", tjiftjaf::QoS::AtLeastOnceDelivery)
             .await
             .unwrap();
 
         handle_2
-            .publish(TOPIC, Bytes::from_static(b"test_subscribe_and_publish"))
+            .publish(
+                "test/client_and_server",
+                Bytes::from_static(b"test_subscribe_and_publish"),
+            )
             .await
             .unwrap();
 
         let publication = handle_1.subscriptions().await.unwrap();
-        assert_eq!(&publication.topic(), &TOPIC);
+        assert_eq!(&publication.topic(), &"test/client_and_server");
         assert_eq!(&publication.payload(), b"test_subscribe_and_publish");
     }
 }


### PR DESCRIPTION
Subscriptions are segmented by `/`.

MQTT allows for using wildcards `+` and `#` in subscriptions.
The `+` matches a single segment. `#` matches any
following segments. See
https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718107

This commit adds support for wild cards. The server
will match an inbound PUBLISH against subscriptions
and consider the wildcards.

Fixes GH-107