### PR TITLE
GH-104 GH-105 Fix parser and reject invalid flags

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 #[derive(Debug)]
 pub struct InvalidPacketTypeError(pub u8);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DecodingError {
     /// The bytes are not enough to decode the packet.
     NotEnoughBytes {

--- a/src/packet/ack.rs
+++ b/src/packet/ack.rs
@@ -8,7 +8,7 @@ use crate::{decode::DecodingError, Frame, PacketType};
 /// * a byte that contains the remaining length, it's always 2.
 /// * 2 bytes to encode the packet identifier.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Ack([u8; 4]);
+pub(crate) struct Ack(pub(crate) [u8; 4]);
 
 impl Ack {
     pub fn new(packet_type: PacketType, packet_identifier: u16) -> Self {

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -67,6 +67,9 @@ impl TryFrom<Vec<u8>> for ConnAck {
         };
 
         if value[0] != 32 {
+            if (value[0] & 0x0F) != 0 {
+                return Err(DecodingError::HeaderContainsInvalidFlags);
+            }
             return Err(DecodingError::InvalidPacketType(value[0]));
         };
 
@@ -212,7 +215,7 @@ impl Default for ConnAckBuilder {
 
 #[cfg(test)]
 mod test {
-    use crate::{packet::connack::ReturnCode, ConnAck};
+    use crate::{packet::connack::ReturnCode, ConnAck, DecodingError, Frame};
 
     #[test]
     fn test_building_connack() {
@@ -240,5 +243,22 @@ mod test {
         // This input is too long.
         let input = vec![32, 2, 0, 0, 0];
         assert!(ConnAck::try_from(input).is_err());
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = ConnAck::builder().build().as_bytes().to_vec();
+        assert!(ConnAck::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            ConnAck::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -67,7 +67,7 @@ impl TryFrom<Vec<u8>> for ConnAck {
         };
 
         if value[0] != 32 {
-            if (value[0] & 0x0F) != 0 {
+            if (value[0] & 0x0F) != 0b0000 {
                 return Err(DecodingError::HeaderContainsInvalidFlags);
             }
             return Err(DecodingError::InvalidPacketType(value[0]));

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -290,6 +290,10 @@ impl UnverifiedConnect {
     }
 
     fn verify_header(&self) -> Result<(), DecodingError> {
+        if self.try_flags()? != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+
         let header = self.try_header()?;
         let packet_type = decode::packet_type(header)?;
         if packet_type != crate::PacketType::Connect {
@@ -853,7 +857,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Connect {
 
 #[cfg(test)]
 mod test {
-    use crate::Connect;
+    use crate::{Connect, DecodingError};
 
     #[test]
     fn test_connect() {
@@ -893,5 +897,22 @@ mod test {
             .will("#", "Optimus died")
             .build()
             .is_err());
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = Connect::builder().build().unwrap().into_bytes();
+        assert!(Connect::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            Connect::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -47,6 +47,10 @@ impl TryFrom<&[u8]> for Disconnect {
             return Err(DecodingError::TooManyBytes);
         }
 
+        if (value[0] & 0x0F) != 0 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+
         Err(DecodingError::Other)
     }
 }
@@ -74,7 +78,7 @@ impl std::fmt::Debug for Disconnect {
 #[cfg(test)]
 mod test {
     use super::Disconnect;
-    use crate::Frame;
+    use crate::{DecodingError, Frame};
 
     #[test]
     fn test_encode_and_decode() {
@@ -90,5 +94,22 @@ mod test {
     fn test_variable_header() {
         // The Disconnect message doesn't have a variable header.
         assert!(Disconnect.variable_header().is_empty())
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = Disconnect {}.as_bytes().to_vec();
+        assert!(Disconnect::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            Disconnect::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -47,7 +47,7 @@ impl TryFrom<&[u8]> for Disconnect {
             return Err(DecodingError::TooManyBytes);
         }
 
-        if (value[0] & 0x0F) != 0 {
+        if (value[0] & 0x0F) != 0b0000 {
             return Err(DecodingError::HeaderContainsInvalidFlags);
         }
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -441,6 +441,20 @@ pub trait UnverifiedFrame {
         self.as_bytes().len()
     }
 
+    fn try_flags(&self) -> Result<u8, DecodingError> {
+        let byte = self
+            .as_bytes()
+            .first()
+            .ok_or(DecodingError::NotEnoughBytes {
+                minimum: 1,
+                actual: 0,
+            })?;
+
+        // The low 4 bits of the first byte contain the flags specific
+        // for the packet type
+        Ok(byte & 0x0F)
+    }
+
     /// Return a slice containing the fixed header.
     fn try_header(&self) -> Result<&[u8], DecodingError> {
         let inner = self.as_bytes();

--- a/src/packet/ping_req.rs
+++ b/src/packet/ping_req.rs
@@ -50,6 +50,10 @@ impl TryFrom<&[u8]> for PingReq {
             return Err(DecodingError::TooManyBytes);
         }
 
+        if (value[0] & 0x0F) != 0 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+
         Err(DecodingError::Other)
     }
 }
@@ -77,7 +81,7 @@ impl std::fmt::Debug for PingReq {
 #[cfg(test)]
 mod test {
     use super::PingReq;
-    use crate::Frame;
+    use crate::{DecodingError, Frame};
 
     #[test]
     fn test_encode_and_decode() {
@@ -93,5 +97,22 @@ mod test {
     fn test_variable_header() {
         // The PingReq message doesn't have a variable header.
         assert!(PingReq.variable_header().is_empty())
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PingReq {}.as_bytes().to_vec();
+        assert!(PingReq::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            PingReq::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/ping_req.rs
+++ b/src/packet/ping_req.rs
@@ -50,7 +50,7 @@ impl TryFrom<&[u8]> for PingReq {
             return Err(DecodingError::TooManyBytes);
         }
 
-        if (value[0] & 0x0F) != 0 {
+        if (value[0] & 0x0F) != 0b0000 {
             return Err(DecodingError::HeaderContainsInvalidFlags);
         }
 

--- a/src/packet/ping_resp.rs
+++ b/src/packet/ping_resp.rs
@@ -47,6 +47,10 @@ impl TryFrom<&[u8]> for PingResp {
             return Err(DecodingError::TooManyBytes);
         }
 
+        if (value[0] & 0x0F) != 0 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+
         Err(DecodingError::Other)
     }
 }
@@ -68,7 +72,7 @@ impl std::fmt::Debug for PingResp {
 #[cfg(test)]
 mod test {
     use super::PingResp;
-    use crate::Frame;
+    use crate::{DecodingError, Frame};
 
     #[test]
     fn test_encode_and_decode() {
@@ -84,5 +88,21 @@ mod test {
     fn test_variable_header() {
         // The PingResp message doesn't have a variable header.
         assert!(PingResp.variable_header().is_empty())
+    }
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PingResp {}.as_bytes().to_vec();
+        assert!(PingResp::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            PingResp::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/ping_resp.rs
+++ b/src/packet/ping_resp.rs
@@ -47,7 +47,7 @@ impl TryFrom<&[u8]> for PingResp {
             return Err(DecodingError::TooManyBytes);
         }
 
-        if (value[0] & 0x0F) != 0 {
+        if (value[0] & 0x0F) != 0b0000 {
             return Err(DecodingError::HeaderContainsInvalidFlags);
         }
 

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -41,11 +41,14 @@ impl TryFrom<&[u8]> for PubAck {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let ack = Ack::try_from(value)?;
-        if ack.packet_type() == PacketType::PubAck {
-            Ok(PubAck(ack))
-        } else {
-            Err(DecodingError::InvalidPacketType(ack.packet_type() as u8))
+        if ack.packet_type() != PacketType::PubAck {
+            return Err(DecodingError::InvalidPacketType(ack.packet_type() as u8));
         }
+
+        if (value[0] & 0x0F) != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+        Ok(Self(ack))
     }
 }
 
@@ -72,6 +75,8 @@ impl std::fmt::Debug for PubAck {
 
 #[cfg(test)]
 mod test {
+    use crate::{DecodingError, Frame};
+
     use super::PubAck;
 
     #[test]
@@ -82,5 +87,22 @@ mod test {
         PubAck::try_from(puback).unwrap();
 
         assert_eq!(puback.packet_identifier(), 1568);
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PubAck::new(15).as_bytes().to_vec();
+        assert!(PubAck::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            PubAck::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -39,11 +39,14 @@ impl TryFrom<&[u8]> for PubComp {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let ack = Ack::try_from(value)?;
-        if ack.packet_type() == PacketType::PubComp {
-            Ok(PubComp(ack))
-        } else {
-            Err(DecodingError::InvalidPacketType(ack.packet_type() as u8))
+        if ack.packet_type() != PacketType::PubComp {
+            return Err(DecodingError::InvalidPacketType(ack.packet_type() as u8));
         }
+
+        if (value[0] & 0x0F) != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+        Ok(Self(ack))
     }
 }
 
@@ -70,6 +73,8 @@ impl std::fmt::Debug for PubComp {
 
 #[cfg(test)]
 mod test {
+    use crate::{DecodingError, Frame};
+
     use super::PubComp;
 
     #[test]
@@ -80,5 +85,21 @@ mod test {
         PubComp::try_from(puback).unwrap();
 
         assert_eq!(puback.packet_identifier(), 1568);
+    }
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PubComp::new(15).as_bytes().to_vec();
+        assert!(PubComp::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            PubComp::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -147,19 +147,19 @@ impl UnverifiedPublish {
     }
 
     fn qos(&self) -> Result<QoS, DecodingError> {
-        let header = self.try_header()?;
-        let flags = header[0] >> 1 & 0b11;
-        QoS::try_from(flags).map_err(|_| DecodingError::InvalidValue("Invalid QoS value".into()))
+        let flags = self.try_flags()?;
+        let qos = flags >> 1 & 0b11;
+        QoS::try_from(qos).map_err(|_| DecodingError::InvalidValue("Invalid QoS value".into()))
     }
 
     fn retain(&self) -> Result<bool, DecodingError> {
-        let header = self.try_header()?;
-        Ok(header[0] & 0b0001 == 0b0001)
+        let flags = self.try_flags()?;
+        Ok(flags & 0b0001 == 0b0001)
     }
 
     fn duplicate(&self) -> Result<bool, DecodingError> {
-        let header = self.try_header()?;
-        Ok(header[0] & 0b1000 == 0b1000)
+        let flags = self.try_flags()?;
+        Ok(flags & 0b1000 == 0b1000)
     }
 
     fn packet_identifier(&self) -> Result<Option<u16>, DecodingError> {

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -39,11 +39,14 @@ impl TryFrom<&[u8]> for PubRec {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let ack = Ack::try_from(value)?;
-        if ack.packet_type() == PacketType::PubRec {
-            Ok(PubRec(ack))
-        } else {
-            Err(DecodingError::InvalidPacketType(ack.packet_type() as u8))
+        if ack.packet_type() != PacketType::PubRec {
+            return Err(DecodingError::InvalidPacketType(ack.packet_type() as u8));
         }
+
+        if (value[0] & 0x0F) != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+        Ok(Self(ack))
     }
 }
 
@@ -70,6 +73,8 @@ impl std::fmt::Debug for PubRec {
 
 #[cfg(test)]
 mod test {
+    use crate::{DecodingError, Frame};
+
     use super::PubRec;
 
     #[test]
@@ -80,5 +85,22 @@ mod test {
         PubRec::try_from(puback).unwrap();
 
         assert_eq!(puback.packet_identifier(), 1568);
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PubRec::new(15).as_bytes().to_vec();
+        assert!(PubRec::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            PubRec::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -7,7 +7,10 @@ pub struct PubRel(Ack);
 
 impl PubRel {
     pub fn new(packet_identifier: u16) -> Self {
-        Self(Ack::new(PacketType::PubRel, packet_identifier))
+        let mut ack = Ack::new(PacketType::PubRel, packet_identifier);
+        // Set the second flag, as per spec.
+        ack.0[0] |= 0b0010;
+        Self(ack)
     }
 
     /// Retrieve the packet identifier.
@@ -39,11 +42,14 @@ impl TryFrom<&[u8]> for PubRel {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let ack = Ack::try_from(value)?;
-        if ack.packet_type() == PacketType::PubRel {
-            Ok(PubRel(ack))
-        } else {
-            Err(DecodingError::InvalidPacketType(ack.packet_type() as u8))
+        if ack.packet_type() != PacketType::PubRel {
+            return Err(DecodingError::InvalidPacketType(ack.packet_type() as u8));
         }
+
+        if (value[0] & 0x0F) != 0b0010 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+        Ok(Self(ack))
     }
 }
 
@@ -70,6 +76,8 @@ impl std::fmt::Debug for PubRel {
 
 #[cfg(test)]
 mod test {
+    use crate::{DecodingError, Frame};
+
     use super::PubRel;
 
     #[test]
@@ -80,5 +88,22 @@ mod test {
         PubRel::try_from(puback).unwrap();
 
         assert_eq!(puback.packet_identifier(), 1568);
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = PubRel::new(15).as_bytes().to_vec();
+        assert!(PubRel::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0001;
+        assert_eq!(
+            PubRel::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -126,6 +126,9 @@ impl UnverifiedSubAck {
     }
 
     fn verify_header(&self) -> Result<(), DecodingError> {
+        if self.try_flags()? != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
         let header = self.try_header()?;
         let packet_type = decode::packet_type(header)?;
         if packet_type != crate::PacketType::SubAck {
@@ -297,5 +300,24 @@ mod test {
             .add_return_code(QoS::AtLeastOnceDelivery)
             .build();
         let _: SubAck = frame.into_bytes().try_into().unwrap();
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = SubAck::builder(15, QoS::AtMostOnceDelivery)
+            .build()
+            .into_bytes();
+        assert!(SubAck::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            SubAck::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -197,7 +197,6 @@ impl UnverifiedSubscribe {
     }
 
     fn verify_header(&self) -> Result<(), DecodingError> {
-        dbg!(self.try_flags()?);
         if self.try_flags()? != 0b0010 {
             return Err(DecodingError::HeaderContainsInvalidFlags);
         }

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -197,6 +197,10 @@ impl UnverifiedSubscribe {
     }
 
     fn verify_header(&self) -> Result<(), DecodingError> {
+        dbg!(self.try_flags()?);
+        if self.try_flags()? != 0b0010 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
         let header = self.try_header()?;
         let packet_type = decode::packet_type(header)?;
         if packet_type != crate::PacketType::Subscribe {
@@ -313,7 +317,9 @@ impl Builder {
 
         let mut packet = Vec::new();
         let packet_type: u8 = PacketType::Subscribe.into();
-        packet.push((packet_type << 4) + 2);
+
+        // Set the second flag, that is required as per specification.
+        packet.push((packet_type << 4) | 0b0010);
 
         let remaining_length = encode::remaining_length(variable_header.len() + payload.len());
         packet.append(&mut remaining_length.to_vec());
@@ -381,5 +387,25 @@ mod test {
         let packet = builder.build().unwrap();
         let topics = packet.filters();
         for _ in topics {}
+    }
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = Subscribe::builder("sensor/1", QoS::AtMostOnceDelivery)
+            .build()
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+        assert!(Subscribe::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0001;
+        assert_eq!(
+            Subscribe::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -39,11 +39,14 @@ impl TryFrom<&[u8]> for UnsubAck {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let ack = Ack::try_from(value)?;
-        if ack.packet_type() == PacketType::UnsubAck {
-            Ok(UnsubAck(ack))
-        } else {
-            Err(DecodingError::InvalidPacketType(ack.packet_type() as u8))
+        if ack.packet_type() != PacketType::UnsubAck {
+            return Err(DecodingError::InvalidPacketType(ack.packet_type() as u8));
         }
+
+        if (value[0] & 0x0F) != 0b0000 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
+        Ok(Self(ack))
     }
 }
 
@@ -70,6 +73,8 @@ impl std::fmt::Debug for UnsubAck {
 
 #[cfg(test)]
 mod test {
+    use crate::{DecodingError, Frame};
+
     use super::UnsubAck;
 
     #[test]
@@ -80,5 +85,21 @@ mod test {
         UnsubAck::try_from(puback).unwrap();
 
         assert_eq!(puback.packet_identifier(), 1568);
+    }
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_parsing_incorrect_flags() {
+        let mut packet = UnsubAck::new(15).as_bytes().to_vec();
+        assert!(UnsubAck::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0010;
+        assert_eq!(
+            UnsubAck::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -165,6 +165,9 @@ impl UnverifiedUnsubscribe {
     }
 
     fn verify_header(&self) -> Result<(), DecodingError> {
+        if self.try_flags()? != 0b0010 {
+            return Err(DecodingError::HeaderContainsInvalidFlags);
+        }
         let header = self.try_header()?;
         let packet_type = decode::packet_type(header)?;
         if packet_type != crate::PacketType::Unsubscribe {
@@ -293,5 +296,25 @@ mod test {
             .build()
             .unwrap();
         let _: Unsubscribe = frame.into_bytes().try_into().unwrap();
+    }
+
+    /// #105 tracks a bug the parser didn't verify a message's flags.
+    /// As result, the parser would happily parse a message with incorrect
+    /// flags. This test verifies that the parser now fails.
+    #[test]
+    fn test_gh_105_fix_reject_incorrect_flags() {
+        let mut packet = Unsubscribe::builder("topic-1")
+            .build()
+            .unwrap()
+            .into_bytes();
+        assert!(Unsubscribe::try_from(packet.clone()).is_ok());
+
+        // The flags are configured in the first byte of the message.
+        // This line changes the flags to an illegal value.
+        packet[0] |= 0b0001;
+        assert_eq!(
+            Unsubscribe::try_from(packet).unwrap_err(),
+            DecodingError::HeaderContainsInvalidFlags
+        );
     }
 }


### PR DESCRIPTION
The low 4 low bits of the first byte contain flags. Until now, the parser didn't verify the flags: it
accept any value.

This commit makes sure to verify the flags. For
most messages, these must be 0.

See https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718022

This commit also fixes GH-104 which tracks an issue where PUBREL messages are generated with wrong flags.

Fixes GH-104 GH-105